### PR TITLE
add streamlit to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,5 @@ uvicorn
 # tests
 httpx
 pytest-asyncio
+
+streamlit


### PR DESCRIPTION
The library streamlit, used by the interface.py was not on the requirements.txt file